### PR TITLE
Add support for generating memory nodes for axi_s6_ddrx

### DIFF
--- a/axi_s6_ddrx/data/axi_s6_ddrx.mdd
+++ b/axi_s6_ddrx/data/axi_s6_ddrx.mdd
@@ -1,0 +1,26 @@
+#
+# (C) Copyright 2014-2015 Xilinx, Inc.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of
+# the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+
+OPTION psf_version = 3.0;
+
+BEGIN driver axi_s6_ddrx
+
+  OPTION supported_peripherals = (axi_s6_ddrx);
+  OPTION supported_os_types = (DTS);
+  OPTION driver_state = ACTIVE;
+  OPTION NAME = axi_s6_ddrx;
+  PARAMETER name = dev_type, default = "memory-controller", type = string;
+  DTGPARAM name = device_type, default = memory, type = string;
+
+END driver

--- a/axi_s6_ddrx/data/axi_s6_ddrx.tcl
+++ b/axi_s6_ddrx/data/axi_s6_ddrx.tcl
@@ -1,0 +1,24 @@
+#
+# (C) Copyright 2014-2015 Xilinx, Inc.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of
+# the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+
+proc generate {drv_handle} {
+    foreach i [get_sw_cores device_tree] {
+        set common_tcl_file "[get_property "REPOSITORY" $i]/data/common_proc.tcl"
+        if {[file exists $common_tcl_file]} {
+            source $common_tcl_file
+            break
+        }
+    }
+    add_memory_node $drv_handle
+}

--- a/device_tree/data/device_tree.mld
+++ b/device_tree/data/device_tree.mld
@@ -36,7 +36,7 @@ PARAMETER name = bootargs, desc = "Booting arguments", type = string, default = 
 PARAMETER name = console_device, desc = "Instance name of IP core for boot console (e.g. RS232_Uart_1, not xps_uart16550)", type = peripheral_instance, range = (axi_uart16550, axi_uartlite, ps7_uart), default = none;
 
 PARAMETER name = periph_type_overrides, desc = "List of peripheral type overrides", type = string, default = "";
-PARAMETER name = main_memory, desc = "Name of Main Memory used with PetaLinux", type = peripheral_instance, range = (ps7_ddr, mpmc, mig_7series, axi_emc), default = none;
+PARAMETER name = main_memory, desc = "Name of Main Memory used with PetaLinux", type = peripheral_instance, range = (ps7_ddr, mpmc, mig_7series, axi_emc, axi_s6_ddrx), default = none;
 PARAMETER name = kernel_version, desc = "Target kernel version", type = enum, values = ("2014.4" = 2014.4, "2015.1" = 2015.1, "2015.2" = 2015.2, "2015.3" = 2015.3 ), default = 2015.3;
 PARAMETER name = pcw_dts, desc = "Target dts filename for PCW configurations", type = string, default = system.dts;
 PARAMETER name = master_dts, desc = "Master dts filename", type = string, default = system.dts;


### PR DESCRIPTION
Some designs still use a Spartan6 FPGA with DDR memories. This commit allows to generate a working device tree for those platforms.