### PR TITLE
AXI DMA and VDMA: change errors for (falsely) unconnected IRQs to warnings

### DIFF
--- a/axi_dma/data/axi_dma.tcl
+++ b/axi_dma/data/axi_dma.tcl
@@ -65,7 +65,7 @@ proc generate {drv_handle} {
             if { [llength $intr_info] && ![string match -nocase $intr_info "-1"] } {
 		    hsi::utils::add_new_dts_param $tx_chan_node "interrupts" $intr_info intlist
             } else {
-		    error "ERROR: ${drv_handle}: mm2s_introut port is not connected"
+		    puts "WARNING: ${drv_handle}: mm2s_introut port is not connected"
             }
             add_dma_coherent_prop $drv_handle "M_AXI_MM2S"
         }
@@ -79,7 +79,7 @@ proc generate {drv_handle} {
             if { [llength $intr_info] && ![string match -nocase $intr_info "-1"] } {
 		    hsi::utils::add_new_dts_param $rx_chan_node "interrupts" $intr_info intlist
             } else {
-		    error "ERROR: ${drv_handle}: s2mm_introut port is not connected"
+		    puts "WARNING: ${drv_handle}: s2mm_introut port is not connected"
             }
             add_dma_coherent_prop $drv_handle "M_AXI_S2MM"
         }

--- a/axi_vdma/data/axi_vdma.tcl
+++ b/axi_vdma/data/axi_vdma.tcl
@@ -66,7 +66,7 @@ proc generate {drv_handle} {
 	        if { [llength $intr_info] && ![string match -nocase $intr_info "-1"] } {
 			hsi::utils::add_new_dts_param $tx_chan_node "interrupts" $intr_info intlist
 	        } else {
-			error "ERROR: ${drv_handle}: mm2s_introut port is not connected"
+			puts "WARNING: ${drv_handle}: mm2s_introut port is not connected"
 		}
 	}
 	set rx_chan [hsi::utils::get_ip_param_value $dma_ip C_INCLUDE_S2MM]
@@ -79,7 +79,7 @@ proc generate {drv_handle} {
 	        if { [llength $intr_info] && ![string match -nocase $intr_info "-1"] } {
 			hsi::utils::add_new_dts_param $rx_chan_node "interrupts" $intr_info intlist
 	        } else {
-			error "ERROR: ${drv_handle}: s2mm_introut port is not connected"
+			puts "WARNING: ${drv_handle}: s2mm_introut port is not connected"
 		}
 	}
 	incr vdma_count


### PR DESCRIPTION
So that the rest of the device tree can be generated correctly.

This code is being hit for IRQs connected to cascaded controllers, and shouldn't be in this case.   Either way it shouldn't error out and completely fail to generate.
