### PR TITLE
axi_dma: Fix dtb compilation issues for 10G designs

### DIFF
--- a/axi_dma/data/axi_dma.tcl
+++ b/axi_dma/data/axi_dma.tcl
@@ -16,8 +16,10 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
+set connected_ip 0
 
 proc generate {drv_handle} {
+    global connected_ip
     # try to source the common tcl procs
     # assuming the order of return is based on repo priority
     foreach i [get_sw_cores device_tree] {
@@ -225,6 +227,7 @@ proc generate_clk_nodes {drv_handle axiethernetfound tx_chan rx_chan} {
 }
 
 proc get_connected_ip {drv_handle dma_pin} {
+    global connected_ip
     # Check whether dma is connected to 10G/25G MAC
     # currently we are handling only data fifo
     set intf [::hsi::get_intf_pins -of_objects [get_cells -hier $drv_handle] $dma_pin]


### PR DESCRIPTION
When AXI DMA connected to 10G Ethenet through axi-stream
fifo, for such designs dtg is generating incorrect label references
for axistream-connected and axistream-control-connected properties
Ex:Undefined Reference to non-existent node or label
"hier_10g_eth_rx_data_fifo_0", Resulting dtb compilation errors.

This patch fixes this issue.

Signed-off-by: Kedareswara rao Appana <appanad@xilinx.com>
Signed-off-by: Claus H. Stovgaard <cst@phaseone.com>