### PR TITLE
Fix rxmem of axiethernet not including width of fifo.

### DIFF
--- a/axi_ethernet/data/axi_ethernet.tcl
+++ b/axi_ethernet/data/axi_ethernet.tcl
@@ -425,7 +425,13 @@ proc get_connectedip {intf} {
             set connected_ip [get_cells -of_objects $target_intf]
             set target_ipname [get_property IP_NAME $connected_ip]
             if {$target_ipname == "axis_data_fifo"} {
+               set fifo_width_bytes [get_property CONFIG.TDATA_NUM_BYTES $connected_ip]
+               if {[string_is_empty $fifo_width_bytes]} {
+                   set fifo_width_bytes 1
+               }
                set rxethmem [get_property CONFIG.FIFO_DEPTH $connected_ip]
+               # FIFO can be other than 8 bits, and we need the rxmem in bytes
+               set rxethmem [expr $rxethmem * $fifo_width_bytes]
             } else {
 	       # In 10G MAC case if the rx_stream interface is not connected to
 	       # a Stream-fifo set the rxethmem value to a default jumbo MTU size


### PR DESCRIPTION
The Linux driver uses the value of rxmem to allow MTU change. And it uses the value in byte, so to allow Jumbo packets on a 10G design using a 64bit width FIFO this need to be taken into account together with the depth.

Signed-off-by: Claus H. Stovgaard <cst@phaseone.com>