### PR TITLE
RFC: Provide mainline Linux support

### DIFF
--- a/device_tree/data/common_proc.tcl
+++ b/device_tree/data/common_proc.tcl
@@ -2661,7 +2661,7 @@ proc gen_root_node {drv_handle} {
 			create_dt_tree_from_dts_file
 			global dtsi_fname
 			update_system_dts_include [file tail ${dtsi_fname}]
-			update_system_dts_include [file tail "zynqmp-clk-ccf.dtsi"]
+			update_system_dts_include [file tail "zynqmp-clk.dtsi"]
 			# no root_node required as zynqmp.dtsi
 			return 0
 		}

--- a/device_tree/data/common_proc.tcl
+++ b/device_tree/data/common_proc.tcl
@@ -638,10 +638,10 @@ proc add_or_get_dt_node args {
 	if {[lsearch $label_list $node_label] >= 0} {
 		set tmp_node [get_node_object ${node_label}]
 		# rename if the node default properties differs
-		if {[dt_node_def_checking $node_label $node_name $node_unit_addr $tmp_node] == 0} {
-			dtg_warning "label '$node_label' found in existing tree, rename to dtg_$node_label"
-			set node_label "dtg_${node_label}"
-		}
+		#if {[dt_node_def_checking $node_label $node_name $node_unit_addr $tmp_node] == 0} {
+		#	dtg_warning "label '$node_label' found in existing tree, rename to dtg_$node_label"
+		#	set node_label "dtg_${node_label}"
+		#}
 	}
 
 	set search_pattern [gen_dt_node_search_pattern -n ${node_name} -l ${node_label} -u ${node_unit_addr}]

--- a/device_tree/data/common_proc.tcl
+++ b/device_tree/data/common_proc.tcl
@@ -1775,8 +1775,9 @@ proc update_clk_node args {
 		set clklist "pl_clk*"
 		foreach pin $pins {
 			if {[regexp $clklist $pin match]} {
-				set pl_clk $pin
-				set is_pl_clk 1
+				# Force fixed clocks
+				#set pl_clk $pin
+				#set is_pl_clk 1
 				if {[string match -nocase $iptype "axi_dma"]} {
 					incr dma_pl_clk_count
 				}
@@ -1800,14 +1801,14 @@ proc update_clk_node args {
 					set clocks [lappend clocks $pl_clk3]
 			}
 			default {
-					dtg_warning "not supported pl_clk:$pl_clk"
+					#dtg_warning "not supported pl_clk:$pl_clk"
 			}
 		}
 		if {[string match -nocase $is_clk_wiz "0"] || [string match -nocase $axi "1"]} {
 			append clocknames " " "$clk_pins"
 			set_drv_prop_if_empty $drv_handle "clock-names" $clocknames stringlist
 		}
-		if {[string match -nocase $is_clk_wiz "0"] && [string match -nocase $is_pl_clk "0"]} {
+		if {[string match -nocase $is_clk_wiz "0"]} {
 			set dts_file "pl.dtsi"
 			set bus_node [add_or_get_bus_node $drv_handle $dts_file]
 			set clk_freq [get_clock_frequency [get_cells -hier $drv_handle] "$clk"]

--- a/device_tree/data/device_tree.tcl
+++ b/device_tree/data/device_tree.tcl
@@ -332,7 +332,7 @@ proc generate {lib_handle} {
     set proctype [get_property IP_NAME [get_cells -hier [get_sw_processor]]]
     if {[string match -nocase $proctype "psu_cortexa53"] } {
 	gen_sata_laneinfo
-	gen_zynqmp_ccf_clk
+	#gen_zynqmp_ccf_clk
     }
     gen_ext_axi_interface
 }

--- a/device_tree/data/kernel_dtsi/2018.1/zynqmp/zynqmp-clk.dtsi
+++ b/device_tree/data/kernel_dtsi/2018.1/zynqmp/zynqmp-clk.dtsi
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Clock specification for Xilinx ZynqMP
+ *
+ * (C) Copyright 2015 - 2018, Xilinx, Inc.
+ *
+ * Michal Simek <michal.simek@xilinx.com>
+ */
+
+/ {
+	clk100: clk100 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <100000000>;
+		u-boot,dm-pre-reloc;
+	};
+
+	clk125: clk125 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <125000000>;
+	};
+
+	clk200: clk200 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <200000000>;
+		u-boot,dm-pre-reloc;
+	};
+
+	clk250: clk250 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <250000000>;
+	};
+
+	clk300: clk300 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <300000000>;
+	};
+
+	clk600: clk600 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <600000000>;
+	};
+
+	dp_aclk: clock0 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <100000000>;
+		clock-accuracy = <100>;
+	};
+
+	dp_aud_clk: clock1 {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <24576000>;
+		clock-accuracy = <100>;
+	};
+
+	dpdma_clk: dpdma_clk {
+		compatible = "fixed-clock";
+		#clock-cells = <0x0>;
+		clock-frequency = <533000000>;
+	};
+
+	drm_clock: drm_clock {
+		compatible = "fixed-clock";
+		#clock-cells = <0x0>;
+		clock-frequency = <262750000>;
+		clock-accuracy = <0x64>;
+	};
+};
+
+&can0 {
+	clocks = <&clk100 &clk100>;
+};
+
+&can1 {
+	clocks = <&clk100 &clk100>;
+};
+
+&fpd_dma_chan1 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&fpd_dma_chan2 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&fpd_dma_chan3 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&fpd_dma_chan4 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&fpd_dma_chan5 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&fpd_dma_chan6 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&fpd_dma_chan7 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&fpd_dma_chan8 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&lpd_dma_chan1 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&lpd_dma_chan2 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&lpd_dma_chan3 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&lpd_dma_chan4 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&lpd_dma_chan5 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&lpd_dma_chan6 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&lpd_dma_chan7 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&lpd_dma_chan8 {
+	clocks = <&clk600>, <&clk100>;
+};
+
+&nand0 {
+	clocks = <&clk100 &clk100>;
+};
+
+&gem0 {
+	clocks = <&clk125>, <&clk125>, <&clk125>;
+};
+
+&gem1 {
+	clocks = <&clk125>, <&clk125>, <&clk125>;
+};
+
+&gem2 {
+	clocks = <&clk125>, <&clk125>, <&clk125>;
+};
+
+&gem3 {
+	clocks = <&clk125>, <&clk125>, <&clk125>;
+};
+
+&gpio {
+	clocks = <&clk100>;
+};
+
+&i2c0 {
+	clocks = <&clk100>;
+};
+
+&i2c1 {
+	clocks = <&clk100>;
+};
+
+&qspi {
+	clocks = <&clk300 &clk300>;
+};
+
+&sata {
+	clocks = <&clk250>;
+};
+
+&sdhci0 {
+	clocks = <&clk200 &clk200>;
+};
+
+&sdhci1 {
+	clocks = <&clk200 &clk200>;
+};
+
+&spi0 {
+	clocks = <&clk200 &clk200>;
+};
+
+&spi1 {
+	clocks = <&clk200 &clk200>;
+};
+
+&uart0 {
+	clocks = <&clk100 &clk100>;
+};
+
+&uart1 {
+	clocks = <&clk100 &clk100>;
+};
+
+&usb0 {
+	clocks = <&clk250>, <&clk250>;
+};
+
+&usb1 {
+	clocks = <&clk250>, <&clk250>;
+};
+
+&watchdog0 {
+	clocks = <&clk250>;
+};
+
+&xilinx_drm {
+	clocks = <&drm_clock>;
+};
+
+&xlnx_dp {
+	clocks = <&dp_aclk>, <&dp_aud_clk>;
+};
+
+&xlnx_dpdma {
+	clocks = <&dpdma_clk>;
+};
+
+&xlnx_dp_snd_codec0 {
+	clocks = <&dp_aud_clk>;
+};

--- a/device_tree/data/kernel_dtsi/2018.1/zynqmp/zynqmp.dtsi
+++ b/device_tree/data/kernel_dtsi/2018.1/zynqmp/zynqmp.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0+
 /*
  * dts file for Xilinx ZynqMP
  *
@@ -5,7 +6,10 @@
  *
  * Michal Simek <michal.simek@xilinx.com>
  *
- * SPDX-License-Identifier:	GPL-2.0+
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
  */
 
 / {
@@ -98,170 +102,6 @@
 		u-boot,dm-pre-reloc;
 	};
 
-	power-domains {
-		compatible = "xlnx,zynqmp-genpd";
-
-		pd_usb0: pd-usb0 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x16>;
-		};
-
-		pd_usb1: pd-usb1 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x17>;
-		};
-
-		pd_sata: pd-sata {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x1c>;
-		};
-
-		pd_spi0: pd-spi0 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x23>;
-		};
-
-		pd_spi1: pd-spi1 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x24>;
-		};
-
-		pd_uart0: pd-uart0 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x21>;
-		};
-
-		pd_uart1: pd-uart1 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x22>;
-		};
-
-		pd_eth0: pd-eth0 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x1d>;
-		};
-
-		pd_eth1: pd-eth1 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x1e>;
-		};
-
-		pd_eth2: pd-eth2 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x1f>;
-		};
-
-		pd_eth3: pd-eth3 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x20>;
-		};
-
-		pd_i2c0: pd-i2c0 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x25>;
-		};
-
-		pd_i2c1: pd-i2c1 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x26>;
-		};
-
-		pd_dp: pd-dp {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x29>;
-		};
-
-		pd_gdma: pd-gdma {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x2a>;
-		};
-
-		pd_adma: pd-adma {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x2b>;
-		};
-
-		pd_ttc0: pd-ttc0 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x18>;
-		};
-
-		pd_ttc1: pd-ttc1 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x19>;
-		};
-
-		pd_ttc2: pd-ttc2 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x1a>;
-		};
-
-		pd_ttc3: pd-ttc3 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x1b>;
-		};
-
-		pd_sd0: pd-sd0 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x27>;
-		};
-
-		pd_sd1: pd-sd1 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x28>;
-		};
-
-		pd_nand: pd-nand {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x2c>;
-		};
-
-		pd_qspi: pd-qspi {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x2d>;
-		};
-
-		pd_gpio: pd-gpio {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x2e>;
-		};
-
-		pd_can0: pd-can0 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x2f>;
-		};
-
-		pd_can1: pd-can1 {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x30>;
-		};
-
-		pd_pcie: pd-pcie {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x3b>;
-		};
-
-		pd_gpu: pd-gpu {
-			#power-domain-cells = <0x0>;
-			pd-id = <0x3a 0x14 0x15>;
-		};
-	};
-
-	/* PMU1<->APU IPI mailbox controller */
-	ipi_mailbox_pmu1: mailbox@ff990400 {
-		compatible = "xlnx,zynqmp-ipi-mailbox";
-		reg = <0x0 0xff9905c0 0x0 0x20>,
-		      <0x0 0xff9905e0 0x0 0x20>,
-		      <0x0 0xff990e80 0x0 0x20>,
-		      <0x0 0xff990ea0 0x0 0x20>;
-		reg-names = "local_request_region", "local_response_region",
-			    "remote_request_region", "remote_response_region";
-		#mbox-cells = <1>;
-		xlnx,ipi-ids = <0 4>;
-		interrupt-parent = <&gic>;
-		interrupts = <0 35 4>;
-	};
-
 	pmu {
 		compatible = "arm,armv8-pmuv3";
 		interrupt-parent = <&gic>;
@@ -276,18 +116,11 @@
 		method = "smc";
 	};
 
-	firmware {
-		zynqmp_firmware: zynqmp-firmware {
-			compatible = "xlnx,zynqmp-firmware";
-			method = "smc";
-		};
-	};
-
-	zynqmp_power: zynqmp-power {
-		compatible = "xlnx,zynqmp-power";
-		mboxes = <&ipi_mailbox_pmu1 0>,
-			 <&ipi_mailbox_pmu1 1>;
-		mbox-names = "tx", "rx";
+	pmufw: firmware {
+		compatible = "xlnx,zynqmp-pm";
+		method = "smc";
+		interrupt-parent = <&gic>;
+		interrupts = <0 35 4>;
 	};
 
 	timer {
@@ -329,12 +162,52 @@
 		#reset-cells = <1>;
 	};
 
-	xlnx_rsa: zynqmp_rsa {
-		compatible = "xlnx,zynqmp-rsa";
+	xlnx_dp_snd_card: dp_snd_card {
+		compatible = "xlnx,dp-snd-card";
+		status = "disabled";
+		xlnx,dp-snd-pcm = <&xlnx_dp_snd_pcm0>, <&xlnx_dp_snd_pcm1>;
+		xlnx,dp-snd-codec = <&xlnx_dp_snd_codec0>;
 	};
 
-	xlnx_keccak_384: sha384 {
-		compatible = "xlnx,zynqmp-keccak-384";
+	xlnx_dp_snd_codec0: dp_snd_codec0 {
+		compatible = "xlnx,dp-snd-codec";
+		status = "disabled";
+		clock-names = "aud_clk";
+	};
+
+	xlnx_dp_snd_pcm0: dp_snd_pcm0 {
+		compatible = "xlnx,dp-snd-pcm";
+		status = "disabled";
+		dmas = <&xlnx_dpdma 4>;
+		dma-names = "tx";
+	};
+
+	xlnx_dp_snd_pcm1: dp_snd_pcm1 {
+		compatible = "xlnx,dp-snd-pcm";
+		status = "disabled";
+		dmas = <&xlnx_dpdma 5>;
+		dma-names = "tx";
+	};
+
+	xilinx_drm: xilinx_drm {
+		compatible = "xlnx,drm";
+		status = "disabled";
+		xlnx,encoder-slave = <&xlnx_dp>;
+		xlnx,connector-type = "DisplayPort";
+		xlnx,dp-sub = <&xlnx_dp_sub>;
+		planes {
+			xlnx,pixel-format = "rgb565";
+			plane0 {
+				dmas = <&xlnx_dpdma 3>;
+				dma-names = "dma0";
+			};
+			plane1 {
+				dmas = <&xlnx_dpdma 0>,
+					<&xlnx_dpdma 1>,
+					<&xlnx_dpdma 2>;
+				dma-names = "dma0", "dma1", "dma2";
+			};
+		};
 	};
 
 	amba_apu: amba_apu@0 {
@@ -372,7 +245,6 @@
 			interrupt-parent = <&gic>;
 			tx-fifo-depth = <0x40>;
 			rx-fifo-depth = <0x40>;
-			power-domains = <&pd_can0>;
 		};
 
 		can1: can@ff070000 {
@@ -384,7 +256,6 @@
 			interrupt-parent = <&gic>;
 			tx-fifo-depth = <0x40>;
 			rx-fifo-depth = <0x40>;
-			power-domains = <&pd_can1>;
 		};
 
 		cci: cci@fd6e0000 {
@@ -417,7 +288,6 @@
 			xlnx,bus-width = <128>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x14e8>;
-			power-domains = <&pd_gdma>;
 		};
 
 		fpd_dma_chan2: dma@fd510000 {
@@ -430,7 +300,6 @@
 			xlnx,bus-width = <128>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x14e9>;
-			power-domains = <&pd_gdma>;
 		};
 
 		fpd_dma_chan3: dma@fd520000 {
@@ -443,7 +312,6 @@
 			xlnx,bus-width = <128>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x14ea>;
-			power-domains = <&pd_gdma>;
 		};
 
 		fpd_dma_chan4: dma@fd530000 {
@@ -456,7 +324,6 @@
 			xlnx,bus-width = <128>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x14eb>;
-			power-domains = <&pd_gdma>;
 		};
 
 		fpd_dma_chan5: dma@fd540000 {
@@ -469,7 +336,6 @@
 			xlnx,bus-width = <128>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x14ec>;
-			power-domains = <&pd_gdma>;
 		};
 
 		fpd_dma_chan6: dma@fd550000 {
@@ -482,7 +348,6 @@
 			xlnx,bus-width = <128>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x14ed>;
-			power-domains = <&pd_gdma>;
 		};
 
 		fpd_dma_chan7: dma@fd560000 {
@@ -495,7 +360,6 @@
 			xlnx,bus-width = <128>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x14ee>;
-			power-domains = <&pd_gdma>;
 		};
 
 		fpd_dma_chan8: dma@fd570000 {
@@ -508,7 +372,6 @@
 			xlnx,bus-width = <128>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x14ef>;
-			power-domains = <&pd_gdma>;
 		};
 
 		gpu: gpu@fd4b0000 {
@@ -519,7 +382,6 @@
 			interrupts = <0 132 4>, <0 132 4>, <0 132 4>, <0 132 4>, <0 132 4>, <0 132 4>;
 			interrupt-names = "IRQGP", "IRQGPMMU", "IRQPP0", "IRQPPMMU0", "IRQPP1", "IRQPPMMU1";
 			clock-names = "gpu", "gpu_pp0", "gpu_pp1";
-			power-domains = <&pd_gpu>;
 		};
 
 		/* LPDDMA default allows only secured access. inorder to enable
@@ -535,8 +397,7 @@
 			clock-names = "clk_main", "clk_apb";
 			xlnx,bus-width = <64>;
 			#stream-id-cells = <1>;
-		/*	iommus = <&smmu 0x868>; */
-			power-domains = <&pd_adma>;
+			iommus = <&smmu 0x868>;
 		};
 
 		lpd_dma_chan2: dma@ffa90000 {
@@ -548,8 +409,7 @@
 			clock-names = "clk_main", "clk_apb";
 			xlnx,bus-width = <64>;
 			#stream-id-cells = <1>;
-		/*	iommus = <&smmu 0x869>; */
-			power-domains = <&pd_adma>;
+			iommus = <&smmu 0x869>;
 		};
 
 		lpd_dma_chan3: dma@ffaa0000 {
@@ -561,8 +421,7 @@
 			clock-names = "clk_main", "clk_apb";
 			xlnx,bus-width = <64>;
 			#stream-id-cells = <1>;
-		/*	iommus = <&smmu 0x86a>; */
-			power-domains = <&pd_adma>;
+			iommus = <&smmu 0x86a>;
 		};
 
 		lpd_dma_chan4: dma@ffab0000 {
@@ -574,8 +433,7 @@
 			clock-names = "clk_main", "clk_apb";
 			xlnx,bus-width = <64>;
 			#stream-id-cells = <1>;
-		/*	iommus = <&smmu 0x86b>; */
-			power-domains = <&pd_adma>;
+			iommus = <&smmu 0x86b>;
 		};
 
 		lpd_dma_chan5: dma@ffac0000 {
@@ -587,8 +445,7 @@
 			clock-names = "clk_main", "clk_apb";
 			xlnx,bus-width = <64>;
 			#stream-id-cells = <1>;
-		/*	iommus = <&smmu 0x86c>; */
-			power-domains = <&pd_adma>;
+			iommus = <&smmu 0x86c>;
 		};
 
 		lpd_dma_chan6: dma@ffad0000 {
@@ -600,8 +457,7 @@
 			clock-names = "clk_main", "clk_apb";
 			xlnx,bus-width = <64>;
 			#stream-id-cells = <1>;
-		/*	iommus = <&smmu 0x86d>; */
-			power-domains = <&pd_adma>;
+			iommus = <&smmu 0x86d>;
 		};
 
 		lpd_dma_chan7: dma@ffae0000 {
@@ -613,8 +469,7 @@
 			clock-names = "clk_main", "clk_apb";
 			xlnx,bus-width = <64>;
 			#stream-id-cells = <1>;
-		/*	iommus = <&smmu 0x86e>; */
-			power-domains = <&pd_adma>;
+			iommus = <&smmu 0x86e>;
 		};
 
 		lpd_dma_chan8: dma@ffaf0000 {
@@ -626,8 +481,7 @@
 			clock-names = "clk_main", "clk_apb";
 			xlnx,bus-width = <64>;
 			#stream-id-cells = <1>;
-		/*	iommus = <&smmu 0x86f>; */
-			power-domains = <&pd_adma>;
+			iommus = <&smmu 0x86f>;
 		};
 
 		mc: memory-controller@fd070000 {
@@ -644,11 +498,10 @@
 			clock-names = "clk_sys", "clk_flash";
 			interrupt-parent = <&gic>;
 			interrupts = <0 14 4>;
-			#address-cells = <1>;
-			#size-cells = <0>;
+			#address-cells = <2>;
+			#size-cells = <1>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x872>;
-			power-domains = <&pd_nand>;
 		};
 
 		gem0: ethernet@ff0b0000 {
@@ -662,7 +515,6 @@
 			#size-cells = <0>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x874>;
-			power-domains = <&pd_eth0>;
 		};
 
 		gem1: ethernet@ff0c0000 {
@@ -676,7 +528,6 @@
 			#size-cells = <0>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x875>;
-			power-domains = <&pd_eth1>;
 		};
 
 		gem2: ethernet@ff0d0000 {
@@ -690,7 +541,6 @@
 			#size-cells = <0>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x876>;
-			power-domains = <&pd_eth2>;
 		};
 
 		gem3: ethernet@ff0e0000 {
@@ -704,7 +554,6 @@
 			#size-cells = <0>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x877>;
-			power-domains = <&pd_eth3>;
 		};
 
 		gpio: gpio@ff0a0000 {
@@ -717,7 +566,6 @@
 			#interrupt-cells = <2>;
 			reg = <0x0 0xff0a0000 0x0 0x1000>;
 			gpio-controller;
-			power-domains = <&pd_gpio>;
 		};
 
 		i2c0: i2c@ff020000 {
@@ -728,7 +576,6 @@
 			reg = <0x0 0xff020000 0x0 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			power-domains = <&pd_i2c0>;
 		};
 
 		i2c1: i2c@ff030000 {
@@ -739,7 +586,6 @@
 			reg = <0x0 0xff030000 0x0 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			power-domains = <&pd_i2c1>;
 		};
 
 		ocm: memory-controller@ff960000 {
@@ -747,24 +593,6 @@
 			reg = <0x0 0xff960000 0x0 0x1000>;
 			interrupt-parent = <&gic>;
 			interrupts = <0 10 4>;
-		};
-
-		perf_monitor_ocm: perf-monitor@ffa00000 {
-			compatible = "xlnx,axi-perf-monitor";
-			reg = <0x0 0xffa00000 0x0 0x10000>;
-			interrupts = <0 25 4>;
-			interrupt-parent = <&gic>;
-			xlnx,enable-profile = <0>;
-			xlnx,enable-trace = <0>;
-			xlnx,num-monitor-slots = <4>;
-			xlnx,enable-event-count = <1>;
-			xlnx,enable-event-log = <1>;
-			xlnx,have-sampled-metric-cnt = <1>;
-			xlnx,num-of-counters = <8>;
-			xlnx,metric-count-width = <32>;
-			xlnx,metrics-sample-count-width = <32>;
-			xlnx,global-count-width = <32>;
-			xlnx,metric-count-scale = <1>;
 		};
 
 		pcie: pcie@fd0e0000 {
@@ -790,13 +618,12 @@
 			reg-names = "breg", "pcireg", "cfg";
 			ranges = <0x02000000 0x00000000 0xe0000000 0x00000000 0xe0000000 0x00000000 0x10000000	/* non-prefetchable memory */
 				  0x43000000 0x00000006 0x00000000 0x00000006 0x00000000 0x00000002 0x00000000>;/* prefetchable memory */
-			interrupt-map-mask = <0x0 0x0 0x0 0x7>;
 			bus-range = <0x00 0xff>;
+			interrupt-map-mask = <0x0 0x0 0x0 0x7>;
 			interrupt-map = <0x0 0x0 0x0 0x1 &pcie_intc 0x1>,
 					<0x0 0x0 0x0 0x2 &pcie_intc 0x2>,
 					<0x0 0x0 0x0 0x3 &pcie_intc 0x3>,
 					<0x0 0x0 0x0 0x4 &pcie_intc 0x4>;
-			power-domains = <&pd_pcie>;
 			pcie_intc: legacy-interrupt-controller {
 				interrupt-controller;
 				#address-cells = <0>;
@@ -818,7 +645,6 @@
 			#size-cells = <0>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x873>;
-			power-domains = <&pd_qspi>;
 		};
 
 		rtc: rtc@ffa60000 {
@@ -832,11 +658,12 @@
 		};
 
 		serdes: zynqmp_phy@fd400000 {
-			compatible = "xlnx,zynqmp-psgtr-v1.1";
+			compatible = "xlnx,zynqmp-psgtr";
 			status = "disabled";
 			reg = <0x0 0xfd400000 0x0 0x40000>,
-			      <0x0 0xfd3d0000 0x0 0x1000>;
-			reg-names = "serdes", "siou";
+			      <0x0 0xfd3d0000 0x0 0x1000>,
+			      <0x0 0xff5e0000 0x0 0x1000>;
+			reg-names = "serdes", "siou", "lpd";
 			nvmem-cells = <&soc_revision>;
 			nvmem-cell-names = "soc_revision";
 			resets = <&rst 16>, <&rst 59>, <&rst 60>,
@@ -867,10 +694,10 @@
 			reg = <0x0 0xfd0c0000 0x0 0x2000>;
 			interrupt-parent = <&gic>;
 			interrupts = <0 133 4>;
-			power-domains = <&pd_sata>;
 			#stream-id-cells = <4>;
 			iommus = <&smmu 0x4c0>, <&smmu 0x4c1>,
 				 <&smmu 0x4c2>, <&smmu 0x4c3>;
+			/* dma-coherent; */
 		};
 
 		sdhci0: sdhci@ff160000 {
@@ -884,7 +711,8 @@
 			xlnx,device_id = <0>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x870>;
-			power-domains = <&pd_sd0>;
+			nvmem-cells = <&soc_revision>;
+			nvmem-cell-names = "soc_revision";
 		};
 
 		sdhci1: sdhci@ff170000 {
@@ -898,11 +726,12 @@
 			xlnx,device_id = <1>;
 			#stream-id-cells = <1>;
 			iommus = <&smmu 0x871>;
-			power-domains = <&pd_sd1>;
+			nvmem-cells = <&soc_revision>;
+			nvmem-cell-names = "soc_revision";
 		};
 
 		pinctrl0: pinctrl@ff180000 {
-			compatible = "xlnx,zynqmp-pinctrl";
+			compatible = "xlnx,pinctrl-zynqmp";
 			status = "disabled";
 			reg = <0x0 0xff180000 0x0 0x1000>;
 		};
@@ -930,7 +759,6 @@
 			clock-names = "ref_clk", "pclk";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			power-domains = <&pd_spi0>;
 		};
 
 		spi1: spi@ff050000 {
@@ -942,7 +770,6 @@
 			clock-names = "ref_clk", "pclk";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			power-domains = <&pd_spi1>;
 		};
 
 		ttc0: timer@ff110000 {
@@ -952,7 +779,6 @@
 			interrupts = <0 36 4>, <0 37 4>, <0 38 4>;
 			reg = <0x0 0xff110000 0x0 0x1000>;
 			timer-width = <32>;
-			power-domains = <&pd_ttc0>;
 		};
 
 		ttc1: timer@ff120000 {
@@ -962,7 +788,6 @@
 			interrupts = <0 39 4>, <0 40 4>, <0 41 4>;
 			reg = <0x0 0xff120000 0x0 0x1000>;
 			timer-width = <32>;
-			power-domains = <&pd_ttc1>;
 		};
 
 		ttc2: timer@ff130000 {
@@ -972,7 +797,6 @@
 			interrupts = <0 42 4>, <0 43 4>, <0 44 4>;
 			reg = <0x0 0xff130000 0x0 0x1000>;
 			timer-width = <32>;
-			power-domains = <&pd_ttc2>;
 		};
 
 		ttc3: timer@ff140000 {
@@ -982,7 +806,6 @@
 			interrupts = <0 45 4>, <0 46 4>, <0 47 4>;
 			reg = <0x0 0xff140000 0x0 0x1000>;
 			timer-width = <32>;
-			power-domains = <&pd_ttc3>;
 		};
 
 		uart0: serial@ff000000 {
@@ -993,7 +816,6 @@
 			interrupts = <0 21 4>;
 			reg = <0x0 0xff000000 0x0 0x1000>;
 			clock-names = "uart_clk", "pclk";
-			power-domains = <&pd_uart0>;
 		};
 
 		uart1: serial@ff010000 {
@@ -1004,7 +826,6 @@
 			interrupts = <0 22 4>;
 			reg = <0x0 0xff010000 0x0 0x1000>;
 			clock-names = "uart_clk", "pclk";
-			power-domains = <&pd_uart1>;
 		};
 
 		usb0: usb0@ff9d0000 {
@@ -1014,7 +835,6 @@
 			compatible = "xlnx,zynqmp-dwc3";
 			reg = <0x0 0xff9d0000 0x0 0x100>;
 			clock-names = "bus_clk", "ref_clk";
-			power-domains = <&pd_usb0>;
 			ranges;
 			nvmem-cells = <&soc_revision>;
 			nvmem-cell-names = "soc_revision";
@@ -1024,15 +844,12 @@
 				status = "disabled";
 				reg = <0x0 0xfe200000 0x0 0x40000>;
 				interrupt-parent = <&gic>;
-				interrupts = <0 65 4>, <0 69 4>, <0 75 4>;
+				interrupts = <0 65 4>, <0 69 4>;
 				#stream-id-cells = <1>;
 				iommus = <&smmu 0x860>;
 				snps,quirk-frame-length-adjustment = <0x20>;
 				snps,refclk_fladj;
-				snps,enable_guctl1_resume_quirk;
-				snps,enable_guctl1_ipd_quirk;
-				snps,xhci-stream-quirk;
-				/* snps,enable-hibernation; */
+				/* dma-coherent; */
 			};
 		};
 
@@ -1043,7 +860,6 @@
 			compatible = "xlnx,zynqmp-dwc3";
 			reg = <0x0 0xff9e0000 0x0 0x100>;
 			clock-names = "bus_clk", "ref_clk";
-			power-domains = <&pd_usb1>;
 			ranges;
 			nvmem-cells = <&soc_revision>;
 			nvmem-cell-names = "soc_revision";
@@ -1053,14 +869,12 @@
 				status = "disabled";
 				reg = <0x0 0xfe300000 0x0 0x40000>;
 				interrupt-parent = <&gic>;
-				interrupts = <0 70 4>, <0 74 4>, <0 76 4>;
+				interrupts = <0 70 4>, <0 74 4>;
 				#stream-id-cells = <1>;
 				iommus = <&smmu 0x861>;
 				snps,quirk-frame-length-adjustment = <0x20>;
 				snps,refclk_fladj;
-				snps,enable_guctl1_resume_quirk;
-				snps,enable_guctl1_ipd_quirk;
-				snps,xhci-stream-quirk;
+				/* dma-coherent; */
 			};
 		};
 
@@ -1099,6 +913,37 @@
 			};
 		};
 
+		xlnx_dp: dp@fd4a0000 {
+			compatible = "xlnx,v-dp";
+			status = "disabled";
+			reg = <0x0 0xfd4a0000 0x0 0x1000>;
+			interrupts = <0 119 4>;
+			interrupt-parent = <&gic>;
+			clock-names = "aclk", "aud_clk";
+			xlnx,dp-version = "v1.2";
+			xlnx,max-lanes = <2>;
+			xlnx,max-link-rate = <540000>;
+			xlnx,max-bpc = <16>;
+			xlnx,enable-ycrcb;
+			xlnx,colormetry = "rgb";
+			xlnx,bpc = <8>;
+			xlnx,audio-chan = <2>;
+			xlnx,dp-sub = <&xlnx_dp_sub>;
+			xlnx,max-pclock-frequency = <300000>;
+		};
+
+		xlnx_dp_sub: dp_sub@fd4aa000 {
+			compatible = "xlnx,dp-sub";
+			status = "disabled";
+			reg = <0x0 0xfd4aa000 0x0 0x1000>,
+			      <0x0 0xfd4ab000 0x0 0x1000>,
+			      <0x0 0xfd4ac000 0x0 0x1000>;
+			reg-names = "blend", "av_buf", "aud";
+			xlnx,output-fmt = "rgb";
+			xlnx,vid-fmt = "yuyv";
+			xlnx,gfx-fmt = "rgb565";
+		};
+
 		xlnx_dpdma: dma@fd4c0000 {
 			compatible = "xlnx,dpdma";
 			status = "disabled";
@@ -1106,7 +951,6 @@
 			interrupts = <0 122 4>;
 			interrupt-parent = <&gic>;
 			clock-names = "axi_clk";
-			power-domains = <&pd_dp>;
 			dma-channels = <6>;
 			#dma-cells = <1>;
 			dma-video0channel {
@@ -1126,60 +970,6 @@
 			};
 			dma-audio1channel {
 				compatible = "xlnx,audio1";
-			};
-		};
-
-		zynqmp_dpsub: zynqmp-display@fd4a0000 {
-			compatible = "xlnx,zynqmp-dpsub-1.7";
-			status = "disabled";
-			reg = <0x0 0xfd4a0000 0x0 0x1000>,
-			      <0x0 0xfd4aa000 0x0 0x1000>,
-			      <0x0 0xfd4ab000 0x0 0x1000>,
-			      <0x0 0xfd4ac000 0x0 0x1000>;
-			reg-names = "dp", "blend", "av_buf", "aud";
-			interrupts = <0 119 4>;
-			interrupt-parent = <&gic>;
-			clock-names = "dp_apb_clk", "dp_aud_clk", "dp_vtc_pixel_clk_in";
-			power-domains = <&pd_dp>;
-
-			vid-layer {
-				dma-names = "vid0", "vid1", "vid2";
-				dmas = <&xlnx_dpdma 0>,
-				       <&xlnx_dpdma 1>,
-				       <&xlnx_dpdma 2>;
-			};
-
-			gfx-layer {
-				dma-names = "gfx0";
-				dmas = <&xlnx_dpdma 3>;
-			};
-
-			/* dummy node to to indicate there's no child i2c device */
-			i2c-bus {
-			};
-
-			zynqmp_dp_snd_codec0: zynqmp_dp_snd_codec0 {
-				compatible = "xlnx,dp-snd-codec";
-				clock-names = "aud_clk";
-			};
-
-			zynqmp_dp_snd_pcm0: zynqmp_dp_snd_pcm0 {
-				compatible = "xlnx,dp-snd-pcm";
-				dmas = <&xlnx_dpdma 4>;
-				dma-names = "tx";
-			};
-
-			zynqmp_dp_snd_pcm1: zynqmp_dp_snd_pcm1 {
-				compatible = "xlnx,dp-snd-pcm";
-				dmas = <&xlnx_dpdma 5>;
-				dma-names = "tx";
-			};
-
-			zynqmp_dp_snd_card0: zynqmp_dp_snd_card {
-				compatible = "xlnx,dp-snd-card";
-				xlnx,dp-snd-pcm = <&zynqmp_dp_snd_pcm0>,
-						  <&zynqmp_dp_snd_pcm1>;
-				xlnx,dp-snd-codec = <&zynqmp_dp_snd_codec0>;
 			};
 		};
 	};

--- a/dp/data/dp.tcl
+++ b/dp/data/dp.tcl
@@ -69,7 +69,9 @@ proc generate_dp_param {drv_handle} {
 			}
 		}
 	}
-	set dp_list "zynqmp_dp_snd_pcm0 zynqmp_dp_snd_pcm1 zynqmp_dp_snd_card0 zynqmp_dp_snd_codec0"
+	# Not available upstream yet
+	#set dp_list "zynqmp_dp_snd_pcm0 zynqmp_dp_snd_pcm1 zynqmp_dp_snd_card0 zynqmp_dp_snd_codec0"
+	set dp_list ""
 	set dts_file [get_property CONFIG.pcw_dts [get_os]]
 	foreach dp_name ${dp_list} {
 		set dp_node [add_or_get_dt_node -n "&${dp_name}" -d $dts_file]


### PR DESCRIPTION
The current device tree magic can only generate device trees for Xilinx downstream kernels. If you want to create a device tree for a custom device with upstream compatibility, you're in a lost course right now.

I've hacked up the current code base to emit an upstream compatible device tree instead, but this obviously breaks downstream support.

I'm more than happy to receive feedback on how to properly integrate mainline support into the Xilinx tree, so that you could also generate an upstream compatible device tree using Xilinx tools.