### PR TITLE
Account for non-standard VCU memory maps

### DIFF
--- a/axi_vcu/data/axi_vcu.tcl
+++ b/axi_vcu/data/axi_vcu.tcl
@@ -24,10 +24,15 @@ proc generate {drv_handle} {
     }
     # Generate properties required for vcu node
     set node [gen_peripheral_nodes $drv_handle]
+    set vcu_ip [get_cells -hier $drv_handle]
+    set baseaddr [get_baseaddr $vcu_ip no_prefix]
+
     hsi::utils::add_new_dts_param "${node}" "#address-cells" 2 int
     hsi::utils::add_new_dts_param "${node}" "#size-cells" 2 int
     set tab "\n\t\t\t\t"
-    set reg "0x0 0xa0040000 0x0 0x1000>,$tab<0x0 0xa0041000 0x0 0x1000"
+    set slcr_addr [format "%08x" [expr 0x$baseaddr + 0x40000]]
+    set logicore_addr [format "%08x" [expr 0x$baseaddr + 0x41000]]
+    set reg [format "0x0 0x%s 0x0 0x1000>,$tab<0x0 0x%s 0x0 0x1000" $slcr_addr $logicore_addr]
     set_drv_prop $drv_handle reg $reg int
     set intr_val [get_property CONFIG.interrupts $drv_handle]
     set intr_parent [get_property CONFIG.interrupt-parent $drv_handle]
@@ -48,20 +53,24 @@ proc generate {drv_handle} {
 
     # Generate child encoder
     set ver [get_ipdetails $drv_handle "ver"]
-    set encoder_node [add_or_get_dt_node -l "encoder" -n "al5e@a0000000" -p $node]
+    set encoder_addr [format "%08x" [expr 0x$baseaddr + 0x00000]]
+    set encoder_name [format "al5e@%s" $encoder_addr]
+    set encoder_node [add_or_get_dt_node -l "encoder" -n $encoder_name -p $node]
     set encoder_comp "al,al5e-${ver}"
     set encoder_comp [append encoder_comp " al,al5e"]
     hsi::utils::add_new_dts_param "${encoder_node}" "compatible" $encoder_comp stringlist
-    set encoder_reg "0x0 0xa0000000 0x0 0x10000"
+    set encoder_reg [format "0x0 0x%s 0x0 0x10000" $encoder_addr]
     hsi::utils::add_new_dts_param "${encoder_node}" "reg" $encoder_reg int
     hsi::utils::add_new_dts_param "${encoder_node}" "interrupts" $intr_val int
     hsi::utils::add_new_dts_param "${encoder_node}" "interrupt-parent" $intr_parent reference
     # Fenerate child decoder
-    set decoder_node [add_or_get_dt_node -l "decoder" -n "al5d@a0020000" -p $node]
+    set decoder_addr [format "%08x" [expr 0x$baseaddr + 0x20000]]
+    set decoder_name [format "al5d@%s" $decoder_addr]
+    set decoder_node [add_or_get_dt_node -l "decoder" -n $decoder_name -p $node]
     set decoder_comp "al,al5d-${ver}"
     set decoder_comp [append decoder_comp " al,al5d"]
     hsi::utils::add_new_dts_param "${decoder_node}" "compatible" $decoder_comp stringlist
-    set decoder_reg "0x0 0xa0020000 0x0 0x10000"
+    set decoder_reg [format "0x0 0x%s 0x0 0x10000" $decoder_addr]
     hsi::utils::add_new_dts_param "${decoder_node}" "reg" $decoder_reg int
     hsi::utils::add_new_dts_param "${decoder_node}" "interrupts" $intr_val int
     hsi::utils::add_new_dts_param "${decoder_node}" "interrupt-parent" $intr_parent reference


### PR DESCRIPTION
The generated `pl.dtsi` always assumes a base address of `0xa0000000`, regardless of what the memory map actually is. This patch updates the logic to use the actual memory map specified by the hardware definition.