### PR TITLE
axi_ethernet: fix DT gen in "PCS/PMA" mode

### DIFF
--- a/axi_ethernet/data/axi_ethernet.tcl
+++ b/axi_ethernet/data/axi_ethernet.tcl
@@ -127,6 +127,8 @@ proc generate {drv_handle} {
 
     if { [llength $intf] } {
         set connected_ip [get_connectedip $intf]
+    } else {
+        set connected_ip ""
     }
 
     foreach n "AXI_STR_RXD m_axis_tx_ts" {
@@ -140,6 +142,7 @@ proc generate {drv_handle} {
         set tx_tsip [get_connectedip $intf]
         set_drv_prop $drv_handle axififo-connected "$tx_tsip" reference
     }
+
     if {![string_is_empty $connected_ip]} {
       set_property axistream-connected "$connected_ip" $drv_handle
       set_property axistream-control-connected "$connected_ip" $drv_handle


### PR DESCRIPTION
When the xxv_ethernet is configured in "Ethernet PCS/PMA 64-bit" mode,
there can be no IPs connected to its RX and TX interfaces.

This commit prevents that the variable `connected_ip` remains undefined
and subsequent errors because of this.