### PR TITLE
The regexps in is_ps_ip and in is_pl_ip match unintended IP

### DIFF
--- a/device_tree/data/common_proc.tcl
+++ b/device_tree/data/common_proc.tcl
@@ -899,7 +899,7 @@ proc is_pl_ip {ip_inst} {
 		return 0
 	}
 	set ip_name [get_property IP_NAME $ip_obj]
-	if {![regexp "ps._*" "$ip_name" match]} {
+	if {![regexp "^ps._" "$ip_name" match]} {
 		return 1
 	}
 	return 0
@@ -914,7 +914,7 @@ proc is_ps_ip {ip_inst} {
 		return 0
 	}
 	set ip_name [get_property IP_NAME $ip_obj]
-	if {[regexp "ps._*" "$ip_name" match]} {
+	if {[regexp "^ps._" "$ip_name" match]} {
 		return 1
 	}
 	return 0


### PR DESCRIPTION
The regexps in is_ps_ip and in is_pl_ip are too broad. They match any IP name that contains ps followed by any character followed by an underscore. The proposed change makes that starting with ps followed by any character followed by an underscore.