### PR TITLE
Fix micro SD card booting issue for ZCU104

### DIFF
--- a/device_tree/data/kernel_dtsi/2021.2/BOARD/zcu104-revc.dtsi
+++ b/device_tree/data/kernel_dtsi/2021.2/BOARD/zcu104-revc.dtsi
@@ -415,6 +415,17 @@
 	pinctrl-0 = <&pinctrl_sdhci1_default>;
 	xlnx,mio-bank = <1>;
 	disable-wp;
+	bus-width = <4>;
+	cd-gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+	cd-debounce-delay-ms = <500>;
+	max-frequency = <100000000>;
+	cap-sd-highspeed;
+	sd-uhs-sdr12;
+	sd-uhs-sdr25;
+	sd-uhs-sdr50;
+	sd-uhs-ddr50;
+	keep-power-in-suspend;
+	status = "okay";
 };
 
 &uart0 {


### PR DESCRIPTION
Sdhci node is not complete to be able to boot rootfs partition from microSD card on ZCU104 board. The issue was fixed in zcu104-revc.dtsi. All of other ZCU board maybe affect in this issue, i advise to test them too and migrate this fix to others too.
<!--
Please do not submit a Pull Request via github. Our project makes use
of mailing lists for patch submission and review. For more details
please see
https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842172/Create+and+Submit+a+Patch
-->