### PR TITLE
Add matching compatible string for debug_bridge driver (Zynq, ZynqMP)

### DIFF
--- a/debug_bridge/data/debug_bridge.tcl
+++ b/debug_bridge/data/debug_bridge.tcl
@@ -28,6 +28,6 @@ proc generate {drv_handle} {
 		return
 	}
 	set compatible [get_comp_str $drv_handle]
-	set compatible [append compatible " " "xlnx,xvc" " " "generic-uio"]
+	set compatible [append compatible " " "xlnx,xvc"]
 	set_drv_prop $drv_handle compatible "$compatible" stringlist
 }

--- a/debug_bridge/data/debug_bridge.tcl
+++ b/debug_bridge/data/debug_bridge.tcl
@@ -28,6 +28,6 @@ proc generate {drv_handle} {
 		return
 	}
 	set compatible [get_comp_str $drv_handle]
-	set compatible [append compatible " " "generic-uio"]
+	set compatible [append compatible " " "xlnx,xvc" " " "generic-uio"]
 	set_drv_prop $drv_handle compatible "$compatible" stringlist
 }


### PR DESCRIPTION
The generated device tree node for the Xilinx Debug Bridge IP in PetaLinux (pl.dtsi) does not match the compatibility string for the device driver. It can be fixed by replacing "generic-uio" appended string with "xlnx,xvc".

ref: https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/644579329/Xilinx+Virtual+Cable#PetaLinux-Device-Tree
