### PR TITLE
dp_rx/data/dp_rx.tcl: unbreak vid_phy direction

### DIFF
--- a/dp_rx/data/dp_rx.tcl
+++ b/dp_rx/data/dp_rx.tcl
@@ -72,7 +72,7 @@ proc generate {drv_handle} {
 		set rxpinname "s_axis_lnk_rx_lane$i"
 		set channelip [get_connected_stream_ip [get_cells -hier $drv_handle] $rxpinname]
 		if {[llength $channelip] && [llength [hsi::utils::get_ip_mem_ranges $channelip]]} {
-			set phy_s "${channelip}rxphy_lane${i} 0 1 1 1"
+			set phy_s "${channelip}rxphy_lane${i} 0 1 1 0"
 			set clocks [lappend clocks $phy_s]
 			set updat  [lappend updat $phy_s]
 		}


### PR DESCRIPTION
Commit edb1f978f719b (vid_phy_ctrl:hdmi_gt_ctrl: Generate Channels only if connected to DP/HDMI) broke the vid_phy direction setting as it set the 4th cell to 1 instead of 0.

As specified by the binding, the 4th cell encodes the phy directions:

  direction_tx = 0 for RX and 1 for TX

https://github.com/Xilinx/dp-modules/blob/xlnx_rel_v2024.1/Documentation/devicetree/bindings/xlnx%2Cvphy.txt

So setting it to 1 doesn't make any sense for the DP receiver core.  This seems to be a cut'n'paste mistake from the similar logic in the DP transmitter core.

Fixes: edb1f978f719b ("vid_phy_ctrl:hdmi_gt_ctrl: Generate Channels only if connected to DP/HDMI")
